### PR TITLE
fixed deprecated modifier /e

### DIFF
--- a/Twilio/Lib/Resource.php
+++ b/Twilio/Lib/Resource.php
@@ -69,16 +69,22 @@ abstract class Resource implements DataProxy
 
     public static function decamelize($word)
     {
-        return preg_replace(
-            '/(^|[a-z])([A-Z])/e',
-            'strtolower(strlen("\\1") ? "\\1_\\2" : "\\2")',
+        return preg_replace_callback('/(^|[a-z])([A-Z])/',
+            function ($matches) {
+                return strtolower(strlen($matches[1]) ? $matches[1] . '_' . $matches[2] : $matches[2]);
+            },
             $word
         );
     }
 
     public static function camelize($word)
     {
-        return preg_replace('/(^|_)([a-z])/e', 'strtoupper("\\2")', $word);
+        return preg_replace_callback('/(^|_)([a-z])/',
+            function ($matches) {
+                return strtoupper($matches[2]);
+            },
+            $word
+        );
     }
 }
 


### PR DESCRIPTION
This PR fixes these warnings:
```
[04-Feb-2015 18:07:02 UTC] PHP Deprecated:  preg_replace(): The /e modifier is deprecated, use preg_replace_callback instead in /srv/www/vacatia/releases/20150122222555/vendor/tsslabs/vresh-twilio-bundle/Vresh/TwilioBundle/Twilio/Lib/Resource.php on line 76
[04-Feb-2015 18:07:02 UTC] PHP Deprecated:  preg_replace(): The /e modifier is deprecated, use preg_replace_callback instead in /srv/www/vacatia/releases/20150122222555/vendor/tsslabs/vresh-twilio-bundle/Vresh/TwilioBundle/Twilio/Lib/Resource.php on line 81
```